### PR TITLE
불필요한 폴더 목록에 xpresseditor 추가

### DIFF
--- a/ko/introduction/xe-upgrade.md
+++ b/ko/introduction/xe-upgrade.md
@@ -103,3 +103,4 @@ XE에 포함되어 있던 아래의 폴더들은 라이믹스에서는 더이상
   - `common/xeicon` (다른 경로로 옮겼음)
   - `doxygen` (불필요)
   - `libs` (다른 경로로 옮겼음)
+  - `modules/editor/skins/xpresseditor` (CKEditor로 대체됨)


### PR DESCRIPTION
https://github.com/rhymix/rhymix/pull/925 에서 xe-core에 있던 xpresseditor가 제거되었는데 마이그레이션 문서에는 관련한 내용이 없어 추가했습니다.